### PR TITLE
Update install for existing Powershell profiles

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -34,12 +34,24 @@ if (!(Test-Path $InstallationPath))
 
 Copy-Item VirtualEnvWrapper.psm1 $InstallationPath\VirtualEnvWrapper.psm1
 
-if (!(Test-Path (Join-Path $PowerShellPath Profile.ps1)))
+# If Powershell profile doesn't exist, add it with necessary contents
+# Otherwise append contents to existing profile
+if (!(Test-Path $profile))
 {
     $key = Ask-User "The powershell profile is missing. Do you want to create it?"
     if ($key -eq "y")
     {
-        Copy-Item Profile.ps1 $PowerShellPath\Profile.ps1
+        Copy-Item Profile.ps1 $profile
+    }
+}
+else
+{
+    $From = Get-Content -Path Profile.ps1
+
+    if(!(Select-String -SimpleMatch "VirtualEnvWrapper.psm1" -Path $profile))
+    {
+        Add-Content -Path $profile -Value "`r`n"
+        Add-Content -Path $profile -Value $From
     }
 }
 

--- a/Profile.ps1
+++ b/Profile.ps1
@@ -1,6 +1,2 @@
-#
-# This is a the few lines you have to add into the file:
-# c:\Users\YOUR_PROFILE\Documents\WindowsPowerShell\WindowsPowerShell_Profile.ps1
-#
 $MyDocuments = [environment]::getfolderpath("mydocuments")
 Import-Module $MyDocuments\WindowsPowerShell\Modules\VirtualEnvWrapper.psm1


### PR DESCRIPTION
Made changes to allow the install to update existing Powershell profiles instead of only working when creating a new profile.

One thing to note is that I removed the comments from Profile.ps1 to simplify the update process.