### PR TITLE
PowerShell Core 7.x Compatibility Fixes

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -4,8 +4,8 @@
 # Installation script
 #
 
-$MyDocuments = [Environment]::GetFolderPath("MyDocuments")
-$PowerShellPath = Join-Path $MyDocuments WindowsPowerShell
+$PowerShellProfile = $PROFILE.CurrentUserAllHosts
+$PowerShellPath = Split-Path $PowerShellProfile
 $InstallationPath = Join-Path $PowerShellPath Modules
 
 function Ask-User($Message)
@@ -36,22 +36,22 @@ Copy-Item VirtualEnvWrapper.psm1 $InstallationPath\VirtualEnvWrapper.psm1
 
 # If Powershell profile doesn't exist, add it with necessary contents
 # Otherwise append contents to existing profile
-if (!(Test-Path $profile))
+if (!(Test-Path $PowerShellProfile))
 {
     $key = Ask-User "The powershell profile is missing. Do you want to create it?"
     if ($key -eq "y")
     {
-        Copy-Item Profile.ps1 $profile
+        Copy-Item Profile.ps1 $PowerShellProfile
     }
 }
 else
 {
     $From = Get-Content -Path Profile.ps1
 
-    if(!(Select-String -SimpleMatch "VirtualEnvWrapper.psm1" -Path $profile))
+    if(!(Select-String -SimpleMatch "VirtualEnvWrapper.psm1" -Path $PowerShellProfile))
     {
-        Add-Content -Path $profile -Value "`r`n"
-        Add-Content -Path $profile -Value $From
+        Add-Content -Path $PowerShellProfile -Value "`r`n"
+        Add-Content -Path $PowerShellProfile -Value $From
     }
 }
 

--- a/Install.ps1
+++ b/Install.ps1
@@ -28,7 +28,7 @@ if ($key -eq "n")
 # Test powershell directories in ~\Documents. If don't exists create it
 if (!(Test-Path $InstallationPath)) 
 {
-    Write-Host "Creaate directory : $InstallationPath"
+    Write-Host "Create directory : $InstallationPath"
     New-Item -ItemType Directory -Force -Path $InstallationPath
 }
 

--- a/Profile.ps1
+++ b/Profile.ps1
@@ -1,2 +1,3 @@
-$MyDocuments = [environment]::getfolderpath("mydocuments")
-Import-Module $MyDocuments\WindowsPowerShell\Modules\VirtualEnvWrapper.psm1
+$PowerShellProfile = $PROFILE.CurrentUserAllHosts
+$PowerShellPath = Split-Path $PowerShellProfile
+Import-Module $PowerShellPath\Modules\VirtualEnvWrapper.psm1


### PR DESCRIPTION
In the open source [PowerShell Core](https://github.com/PowerShell/PowerShell), the directory containing the user's profile is `PowerShell` instead of `WindowsPowerShell`. Instead of finding the `MyDocuments` directory and building up the profile path from there, hardcoding in `WindowsPowerShell`, the proposed changes utilize the `$PROFILE` variable itself to determine the path to use for profile edits.

It was determined from profile path used in the existing Install.ps1 script that the targeted profile is the one for the [current user, and all hosts](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.1). Therefore, this profile is hardcoded in as the default profile in the proposed script as well.

This provides compatibility between Windows PowerShell 5.1 shipped with Windows, and [PowerShell Core](https://github.com/PowerShell/PowerShell), automatically setting the correct profile directory.