### PR TITLE
Fix Get-VirtualEnvs for PS 7.0+

### DIFF
--- a/VirtualEnvWrapper.psm1
+++ b/VirtualEnvWrapper.psm1
@@ -354,8 +354,8 @@ function Get-VirtualEnvs {
         for($i = 0; $i -lt $children.Length; $i++) {
             $child = $children[$i]
             try {
-                $PythonVersion = (((Invoke-Expression ("$WORKON_HOME\{0}\Scripts\Python.exe --version 2>&1" -f "$child")) -replace "`r|`n","") -Split " ")[1]
-                Write-host ("`t{0,-30}{1,-15}" -f $child,$PythonVersion)
+                $PythonVersion = (((Invoke-Expression ("$WORKON_HOME\{0}\Scripts\Python.exe --version 2>&1" -f $child.name)) -replace "`r|`n","") -Split " ")[1]
+                Write-host ("`t{0,-30}{1,-15}" -f $child.name,$PythonVersion)
             } catch {
                 $failed += $child
             }

--- a/VirtualEnvWrapper.psm1
+++ b/VirtualEnvWrapper.psm1
@@ -365,7 +365,7 @@ function Get-VirtualEnvs {
     }
     if ($failed.Length -gt 0) {
         Write-Host
-        Write-Host "`tAdditionnaly, one or more environments failed to be listed"
+        Write-Host "`tAdditionally, one or more environments failed to be listed"
         Write-Host "`t=========================================================="
         Write-Host
         foreach ($item in $failed) {


### PR DESCRIPTION
In Powershell 7+ the objects returned by Get-ChildItem expand to the full path by default versus just the subpath. Using $child.name works in both versions.
