### PR TITLE
Add -force option to module activation

### DIFF
--- a/VirtualEnvWrapper.psm1
+++ b/VirtualEnvWrapper.psm1
@@ -247,7 +247,7 @@ function Workon {
         return
     }
 
-    Import-Module $activate_path
+    Import-Module $activate_path -Force
 
     $Env:OLD_PYTHON_PATH = $Env:PYTHON_PATH
     $Env:VIRTUAL_ENV = "$new_pyenv"


### PR DESCRIPTION
This change addresses issue: https://github.com/regisf/virtualenvwrapper-powershell/issues/25, where you are unable to call workon after calling deactivate. Forcing the reload resolves the issue for me. I tested this on Powershell version 5.1, but checking the Microsoft docs the `-force` parameter is available back through version 3.